### PR TITLE
cleanup: Remove debug print statements and clean up commented code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-# Use an official Python runtime as the base image
-# FROM python:3.12-slim
 # Base image with GPU support
-# FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 FROM nvidia/cuda:13.0.0-devel-ubuntu22.04
 
 # Set CUDA and NVIDIA library paths
@@ -143,15 +140,9 @@ RUN pip install -e proofgrader_repo
 # Download things for balrog domains
 RUN python -m domains.balrog.scripts.post_install
 
-# For Genesis: install PyTorch with CUDA support
+# For Genesis: install PyTorch with CUDA 13.0 support
 # First check the Cuda version: nvidia-smi
-# If Cuda version is 11.8:
-# RUN pip install --no-cache-dir torch==2.1.0 torchvision==0.16.0 --index-url https://download.pytorch.org/whl/cu118
-# If Cuda version is 12.1:
-# RUN pip install --no-cache-dir torch==2.1.0 torchvision==0.16.0 --index-url https://download.pytorch.org/whl/cu121
-# If Cuda version is 12.4:
-# RUN pip install --no-cache-dir torch==2.6.0 torchvision==0.21.0 --index-url  https://download.pytorch.org/whl/cu124
-# If Cuda version is 13.0:
+# For other CUDA versions, adjust the --index-url accordingly (e.g., cu118, cu121, cu124)
 RUN pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
 
 # Ensure the libcuda symlink fix runs before your command

--- a/domains/genesis/genesis_utils.py
+++ b/domains/genesis/genesis_utils.py
@@ -45,7 +45,6 @@ def collect_and_summarize_results(output_dir):
         for dir in dirs
         if dir.startswith("genesis_eval")
     ]
-    print(f"DEBUG: Found genesis_eval directories: {genesis_eval_dirs}")
 
     # From each genesis_eval/ folder, find all .json files
     json_files = []
@@ -55,7 +54,6 @@ def collect_and_summarize_results(output_dir):
                 if filename.endswith(".json"):
                     json_filepath = os.path.join(root, filename)
                     json_files.append(json_filepath)
-    print(f"DEBUG: Found JSON files: {json_files}")
 
     # Each json file is a separate run, so we need to group them by tasks
     # Each json file has the name format of {task}_run_{run_id}.json


### PR DESCRIPTION
## Summary
- Remove DEBUG print statements in `domains/genesis/genesis_utils.py` (lines 48, 58)
- Clean up unused commented base images in `Dockerfile`
- Consolidate PyTorch CUDA installation comments for better readability

## Details
The debug print statements were left in from development and are no longer needed. This PR removes them to clean up the codebase.

The Dockerfile had multiple commented-out base image options and CUDA version instructions that have been cleaned up to improve readability while preserving the important information about alternative CUDA versions.

## Test plan
- [ ] Code changes are minimal and straightforward
- [ ] No functional changes to the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)