### PR TITLE
docs: Remove placeholder logo comment from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 <div align="center">
-
-<!-- Logo/Banner placeholder - uncomment and add your image -->
-<!-- <img src="assets/banner.png" alt="HyperAgents Banner" width="800"> -->
-
 <h1>HyperAgents</h1>
 
 <p>Self-referential self-improving agents that can optimize for any computable task</p>


### PR DESCRIPTION
## Summary
Remove the commented-out logo/banner placeholder that was left in from the template.

## Details
The README contained a placeholder comment for a logo image:
```html
<!-- Logo/Banner placeholder - uncomment and add your image -->
<!-- <img src="assets/banner.png" alt="HyperAgents Banner" width="800"> -->
```

This placeholder has been removed to clean up the README. If a logo is added in the future, it can be added without the placeholder comment.

## Test plan
- [ ] Documentation-only change, no testing needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)